### PR TITLE
Fixes Upstream Issue 349 - tag link has double forward slash

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -8,7 +8,11 @@
         {{ if .Params.tags }}
           <div class="blog-tags">
             {{ range .Params.tags }}
+              <!-- Fix for "https://github.com/halogenica/beautifulhugo/issues/349".
+              Inspired by "https://github.com/dovidio/personalwebsite/commit/34762e94c29fd2c26c16c45f8ae2de21bdf9b46d".
               <a href="{{ $.Site.LanguagePrefix | absURL }}/tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
+              -->
+              <a href="{{"tags" | absLangURL}}/{{ . | urlize }}/">{{ . }}</a>&nbsp;
             {{ end }}
           </div>
         {{ end }}

--- a/layouts/partials/post_preview.html
+++ b/layouts/partials/post_preview.html
@@ -31,8 +31,12 @@
     {{ if .Params.tags }}
     <div class="blog-tags">
         {{ range .Params.tags }}
-        <a href="{{ $.Site.LanguagePrefix | absURL }}/tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
-        {{ end }}
+       <!-- Fix for "https://github.com/halogenica/beautifulhugo/issues/349".
+       From "https://github.com/dovidio/personalwebsite/commit/34762e94c29fd2c26c16c45f8ae2de21bdf9b46d".
+       <a href="{{ $.Site.LanguagePrefix | absURL }}/tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
+       -->
+       <a href="{{"tags" | absLangURL}}/{{ . | urlize }}/">{{ . }}</a>&nbsp;
+        {{ end }} 
     </div>
     {{ end }}
 


### PR DESCRIPTION
Fix for "#349" where "tags" have double forward slashes causing broken links.
Takes the fix from "dovidio/personalwebsite@34762e9" for "layouts/partials/post_preview.html" and extends it to also fix "layouts/_default/single.html".